### PR TITLE
Add filter for missing tool/slave

### DIFF
--- a/QueueSystems/ErrorHandling/Console/NotInstalled/config.texttest
+++ b/QueueSystems/ErrorHandling/Console/NotInstalled/config.texttest
@@ -1,3 +1,5 @@
+import_config_file:no_such_filter
+
 [run_dependent_text]
 pythonmocks:env=\{.*{REPLACE env=<something>}
 pythonmocks:env={->}}, startupinfo

--- a/TestSelf/FileViewers/Console/BadViewers/config.texttest
+++ b/TestSelf/FileViewers/Console/BadViewers/config.texttest
@@ -1,0 +1,1 @@
+import_config_file:no_such_filter

--- a/no_such_filter
+++ b/no_such_filter
@@ -1,0 +1,5 @@
+# -*- conf-colon -*-
+
+[run_dependent_text]
+output:('no_such_(tool|slave)')(: 'no_such_.*')?{REPLACE \1}
+[end]


### PR DESCRIPTION
Possibly due to linux/windows differences. We get e.g `No such file or directory: 'no_such_slave': 'no_such_slave`