### PR TITLE
Fix test QueueSystems/NormalOperation/Console/Batch2Tests

### DIFF
--- a/config.texttest.condor
+++ b/config.texttest.condor
@@ -9,3 +9,4 @@ submitfile_*:[^/]*[0-9]{2}[A-Za-z][a-z][a-z][0-9]{6}\.[0-9]*{REPLACE <target tmp
 submitfile_*:[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*:[0-9]*{REPLACE <host:port>}
 submitfile_*:[^ ]*/texttestc?[\.py]* {REPLACE <path_to_texttest> }
 submitfile_*:[^ ]*python3?.exe{REPLACE <path_to_python> }
+submitfile_*:[^ ]*/bin/texttest{REPLACE <texttest_executable>}


### PR DESCRIPTION
The test located at `QueueSystems/NormalOperation/Console/Batch2Tests` has a path pointing to `/users/geoff/.local/texttest_test/bin/texttest` in both submitfiles. When running with another texttest bin path, this test fails. It is not run within the CI system, which explains why the CI is green even without this change.